### PR TITLE
Remove duplicate rspec reference in gemspec

### DIFF
--- a/wiselinks.gemspec
+++ b/wiselinks.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'bundler'
   gem.add_development_dependency 'sqlite3'
-  gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rspec-rails'
   gem.add_development_dependency 'factory_girl'
   gem.add_development_dependency 'faker'


### PR DESCRIPTION
This duplicate is causing bundler to silently choke on this gem.  I'm pointing my local to my copy until this is resolved.
